### PR TITLE
Speed up the calculation of Hessian matrix

### DIFF
--- a/LogisticRegression/ML_LogisticRegression.py
+++ b/LogisticRegression/ML_LogisticRegression.py
@@ -131,12 +131,7 @@ class LogisticRegressionSelf(object):
         Hw: array, shape=(n_features+1, n_features+1)
             海塞矩阵
         """
-        Hw = np.dot(np.dot(X.T, np.dot(np.diag(Ypre.reshape(-1)), np.diag(1-Ypre.reshape(-1)))), X)
-        #为了更直观的理解，展示下拆解开求解的方法
-        #Hw = np.zeros((X.shape[1], X.shape[1]))
-        #for i in range(n_samples):
-        #    xxt = np.dot(X[i,:].reshape(-1,1),X[i,:].reshape(1,-1))
-        #    Hw += xxt*Ypre[i]*(1-Ypre[i])
+        Hw = X.T@(X*Ypre*(1-Ypre))
         return Hw
         
     #训练，梯度下降法


### PR DESCRIPTION
加速求解黑塞矩阵

知乎答主您好，牛顿法大多数时候计算成本很高，但是在逻辑斯蒂回归里面反而比较好算。试一试把计算黑塞矩阵的代码改成 Hw = X.T@(X\*Ypre\*(1-Ypre))，会快很多，因为不需要来回变换矩阵维数。已经在知乎评论了，不知道答主是否愿意采纳~